### PR TITLE
Add Interval Tree and modernize repo

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
 [submodule "tests/googletest"]
 	path = tests/googletest
 	url = https://github.com/google/googletest.git
-[submodule "benchmark/matplotplusplus"]
-	path = benchmark/matplotplusplus
-	url = https://github.com/alandefreitas/matplotplusplus/

--- a/README.md
+++ b/README.md
@@ -26,3 +26,7 @@ Heap
 
 Threading: 
 - Launching Threadpool (Submit jobs, launch at once)
+
+Spatial: 
+- KD-Tree
+- Interval Tree

--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -27,8 +27,6 @@ target_include_directories(treeutils PUBLIC inc)
 # All benchmark suites need this include directory
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/inc)
 
-add_subdirectory(matplotplusplus)
-
 function(addBenchmark benchmarkname src)
     add_executable(${benchmarkname} ${src})
     target_link_libraries(${benchmarkname} benchmark ${ARGN})
@@ -39,7 +37,7 @@ addBenchmark(quack quack.cpp)
 addBenchmark(iteration listIteration.cpp)
 addBenchmark(trees balancedTrees.cpp treeutils)
 addBenchmark(scapegoatTrees scapegoat-trees.cpp treeutils)
-addBenchmark(dijkstra dijkstra.cpp graph matplot)
+addBenchmark(dijkstra dijkstra.cpp graph)
 addBenchmark(heaps heaps.cpp)
 addBenchmark(medians medians.cpp)
 addBenchmark(kdtree kd-tree.cpp)

--- a/benchmark/dijkstra.cpp
+++ b/benchmark/dijkstra.cpp
@@ -15,9 +15,6 @@
 #include "heap/pairing.hpp"
 #include "interfaces.hpp"
 
-// Matplot++
-#include <matplot/matplot.h>
-
 
 
 /**
@@ -62,34 +59,6 @@ std::vector<uint16_t> dijkstra(Graph *g){
     return paths;
 }
 
-void plot(BenchmarkSuite& suite, std::string filename){
-    // Plotting results: Need to group by the test name. 
-    //Test name has xs, avgs, stdevs
-    using namespace matplot;
-
-
-    // title(suite.suiteName_);
-    xlabel("Input Size");
-    ylabel("Time (s)");
-    auto groupedResults = suite.getGroupedResults();
-    
-    for (auto &[name, g] : groupedResults)
-    {
-        hold(on);
-        error_bar_handle h = errorbar(g.inputSizes_, g.times_, g.stdevs_, "-");
-        h->display_name(name);
-        h->line_width(1.5);
-        hold(off);
-    }
-    legend_handle l = ::matplot::legend({});
-    l->location(legend::general_alignment::topleft);
-
-    if (filename == ""){
-        show();
-    } else {
-        save(filename, "jpeg");
-    }
-}
 
 int main(){
 

--- a/inc/spatial/intervalTree-private.hpp
+++ b/inc/spatial/intervalTree-private.hpp
@@ -1,19 +1,19 @@
 #include "intervalTree.hpp"
 
-template <typename T, Interval I>
-IntervalTree<T, I>::IntervalTree():
+template <Interval I>
+IntervalTree<I>::IntervalTree():
 root_{new Node(std::numeric_limits<T>::min(), std::numeric_limits<T>::max())}, size_{0}
 {
 }
 
-template <typename T, Interval I>
-IntervalTree<T, I>::~IntervalTree()
+template <Interval I>
+IntervalTree<I>::~IntervalTree()
 {
     destroyTree(root_);
 }
 
-template <typename T, Interval I>
-void IntervalTree<T, I>::destroyTree(Node* n){
+template <Interval I>
+void IntervalTree<I>::destroyTree(Node* n){
     if (n){
         if (n->left_){
             destroyTree(n->left_);
@@ -25,13 +25,13 @@ void IntervalTree<T, I>::destroyTree(Node* n){
     }
 }
 
-template <typename T, Interval I>
-void IntervalTree<T, I>::insert(const T &low, const T &high){
+template <Interval I>
+void IntervalTree<I>::insert(const T &low, const T &high){
     insert(I{low, high});
 }
 
-template <typename T, Interval I>
-void IntervalTree<T, I>::insert(const I& i){
+template <Interval I>
+void IntervalTree<I>::insert(const I& i){
 // First check if both endpoints are in the tree before adding them
     const T& low = i.low();
     const T& high = i.high();
@@ -50,8 +50,8 @@ void IntervalTree<T, I>::insert(const I& i){
     return;
 }
 
-template <typename T, Interval I>
-void IntervalTree<T, I>::insertNode(const T& value, Node*&node){
+template <Interval I>
+void IntervalTree<I>::insertNode(const T& value, Node*&node){
     if (node->isLeaf_){
         node->isLeaf_ = false;
         node->value_ = value;
@@ -64,8 +64,8 @@ void IntervalTree<T, I>::insertNode(const T& value, Node*&node){
     }
 }
 
-template <typename T, Interval I>
-void IntervalTree<T, I>::insertInterval(size_t intervalInd, Node*&node){
+template <Interval I>
+void IntervalTree<I>::insertInterval(size_t intervalInd, Node*&node){
     const I &i = allIntervals_[intervalInd];
     // Case where the node's subtree is fully contained in the interval
     if (node->min_ >= i.low() and node->max_ <= i.high())
@@ -88,8 +88,8 @@ void IntervalTree<T, I>::insertInterval(size_t intervalInd, Node*&node){
     }
 }
 
-template <typename T, Interval I>
-void IntervalTree<T, I>::query(const T& queryPoint,std::unordered_set<size_t>& intervals, Node* n) const{
+template <Interval I>
+void IntervalTree<I>::query(const T& queryPoint,std::unordered_set<size_t>& intervals, Node* n) const{
     intervals.insert(n->intervals_.begin(), n->intervals_.end());
     if (n->isLeaf_) {
         return;
@@ -103,8 +103,8 @@ void IntervalTree<T, I>::query(const T& queryPoint,std::unordered_set<size_t>& i
     } 
 }
 
-template <typename T, Interval I>
-std::vector<I> IntervalTree<T, I>::findOverlaps(const T& queryPoint){
+template <Interval I>
+std::vector<I> IntervalTree<I>::findOverlaps(const T& queryPoint){
     std::unordered_set<size_t> overlapInds;
     query(queryPoint, overlapInds,root_);
     std::vector<I> overlapIntervals;
@@ -115,8 +115,8 @@ std::vector<I> IntervalTree<T, I>::findOverlaps(const T& queryPoint){
     return overlapIntervals;
 }
 
-template <typename T, Interval I>
-std::vector<I> IntervalTree<T, I>::findSupersets(const T &low, const T &high){
+template <Interval I>
+std::vector<I> IntervalTree<I>::findSupersets(const T &low, const T &high){
     std::unordered_set<size_t> overlapLow;
     std::unordered_set<size_t> overlapHigh;
     query(low, overlapLow, root_);
@@ -145,8 +145,8 @@ bool ITree::Interval<T>::operator==(const Interval<T>& other) const {
     return (low_ == other.low_) && (high_ == other.high_);
 }
 
-template <typename T, Interval I>
-IntervalTree<T, I>::Node::Node(T min, T max):
+template <Interval I>
+IntervalTree<I>::Node::Node(T min, T max):
     left_{nullptr}, 
     right_{nullptr}, 
     min_{min},

--- a/inc/spatial/intervalTree-private.hpp
+++ b/inc/spatial/intervalTree-private.hpp
@@ -1,19 +1,19 @@
 #include "intervalTree.hpp"
 
-template <typename T>
-IntervalTree<T>::IntervalTree():
+template <typename T, Interval I>
+IntervalTree<T, I>::IntervalTree():
 root_{new Node(std::numeric_limits<T>::min(), std::numeric_limits<T>::max())}, size_{0}
 {
 }
 
-template <typename T>
-IntervalTree<T>::~IntervalTree()
+template <typename T, Interval I>
+IntervalTree<T, I>::~IntervalTree()
 {
     destroyTree(root_);
 }
 
-template <typename T>
-void IntervalTree<T>::destroyTree(Node* n){
+template <typename T, Interval I>
+void IntervalTree<T, I>::destroyTree(Node* n){
     if (n){
         if (n->left_){
             destroyTree(n->left_);
@@ -25,9 +25,16 @@ void IntervalTree<T>::destroyTree(Node* n){
     }
 }
 
-template <typename T>
-void IntervalTree<T>::insert(const T &low, const T &high){
-    // First check if both endpoints are in the tree before adding them
+template <typename T, Interval I>
+void IntervalTree<T, I>::insert(const T &low, const T &high){
+    insert(I{low, high});
+}
+
+template <typename T, Interval I>
+void IntervalTree<T, I>::insert(const I& i){
+// First check if both endpoints are in the tree before adding them
+    const T& low = i.low();
+    const T& high = i.high();
     if (!allEndpoints_.contains(low)){
         insertNode(low, root_);
         allEndpoints_.insert(low);
@@ -36,21 +43,15 @@ void IntervalTree<T>::insert(const T &low, const T &high){
         insertNode(high, root_);
         allEndpoints_.insert(high);
     }
-    allIntervals_.push_back(Interval{low, high});
+    allIntervals_.push_back(i);
     // Insert the INDEX of the interval into each node
     insertInterval(size_, root_);
     ++size_;
     return;
 }
 
-template <typename T>
-void IntervalTree<T>::insert(const Interval& i){
-    insert(i.low_, i.high_);
-    return;
-}
-
-template <typename T>
-void IntervalTree<T>::insertNode(const T& value, Node*&node){
+template <typename T, Interval I>
+void IntervalTree<T, I>::insertNode(const T& value, Node*&node){
     if (node->isLeaf_){
         node->isLeaf_ = false;
         node->value_ = value;
@@ -63,11 +64,11 @@ void IntervalTree<T>::insertNode(const T& value, Node*&node){
     }
 }
 
-template <typename T>
-void IntervalTree<T>::insertInterval(size_t intervalInd, Node*&node){
-    const Interval &i = allIntervals_[intervalInd];
+template <typename T, Interval I>
+void IntervalTree<T, I>::insertInterval(size_t intervalInd, Node*&node){
+    const I &i = allIntervals_[intervalInd];
     // Case where the node's subtree is fully contained in the interval
-    if (node->min_ >= i.low_ and node->max_ <= i.high_)
+    if (node->min_ >= i.low() and node->max_ <= i.high())
     {
         node->intervals_.push_back(intervalInd);
     }
@@ -78,17 +79,17 @@ void IntervalTree<T>::insertInterval(size_t intervalInd, Node*&node){
         if (node->isLeaf_){
             throw std::logic_error("Node cannot be a leaf here");
         }
-        if (i.low_ < node->value_){
+        if (i.low() < node->value_){
             insertInterval(intervalInd, node->left_);
         } 
-        if (node->value_ < i.high_){
+        if (node->value_ < i.high()){
             insertInterval(intervalInd, node->right_);
         }
     }
 }
 
-template <typename T>
-void IntervalTree<T>::query(const T& queryPoint,std::unordered_set<size_t>& intervals, Node* n) const{
+template <typename T, Interval I>
+void IntervalTree<T, I>::query(const T& queryPoint,std::unordered_set<size_t>& intervals, Node* n) const{
     intervals.insert(n->intervals_.begin(), n->intervals_.end());
     if (n->isLeaf_) {
         return;
@@ -102,32 +103,30 @@ void IntervalTree<T>::query(const T& queryPoint,std::unordered_set<size_t>& inte
     } 
 }
 
-template <typename T>
-std::vector<std::pair<T, T>> IntervalTree<T>::findOverlaps(const T& queryPoint){
+template <typename T, Interval I>
+std::vector<I> IntervalTree<T, I>::findOverlaps(const T& queryPoint){
     std::unordered_set<size_t> overlapInds;
     query(queryPoint, overlapInds,root_);
-    std::vector<std::pair<T, T>> overlapIntervals;
+    std::vector<I> overlapIntervals;
     for (size_t intervalInd : overlapInds)
     {
-        const Interval &i = allIntervals_[intervalInd];
-        overlapIntervals.push_back({i.low_, i.high_});
+        overlapIntervals.push_back(allIntervals_[intervalInd]);
     }
     return overlapIntervals;
 }
 
-template <typename T>
-std::vector<std::pair<T, T>> IntervalTree<T>::findSupersets(const T &low, const T &high){
+template <typename T, Interval I>
+std::vector<I> IntervalTree<T, I>::findSupersets(const T &low, const T &high){
     std::unordered_set<size_t> overlapLow;
     std::unordered_set<size_t> overlapHigh;
-    query(low, overlapLow,root_);
-    query(high, overlapHigh,root_);
-    std::vector<std::pair<T, T>> overlapIntervals;
+    query(low, overlapLow, root_);
+    query(high, overlapHigh, root_);
+    std::vector<I> overlapIntervals;
     // Find Intersection of sets
     for (size_t intervalInd : overlapHigh){
         // Both contain this interval
         if (overlapLow.contains(intervalInd)){
-            const Interval &i = allIntervals_[intervalInd];
-            overlapIntervals.push_back({i.low_, i.high_});
+            overlapIntervals.push_back(allIntervals_[intervalInd]);
         }
     }
     return overlapIntervals;
@@ -136,13 +135,18 @@ std::vector<std::pair<T, T>> IntervalTree<T>::findSupersets(const T &low, const 
 // Struct Functions
 
 template <typename T>
-IntervalTree<T>::Interval::Interval(T low, T high):
+ITree::Interval<T>::Interval(T low, T high):
     low_{low}, high_{high}{
         // Nothing here
 }
 
-template<typename T>
-IntervalTree<T>::Node::Node(T min, T max):
+template <typename T>
+bool ITree::Interval<T>::operator==(const Interval<T>& other) const {
+    return (low_ == other.low_) && (high_ == other.high_);
+}
+
+template <typename T, Interval I>
+IntervalTree<T, I>::Node::Node(T min, T max):
     left_{nullptr}, 
     right_{nullptr}, 
     min_{min},

--- a/inc/spatial/intervalTree-private.hpp
+++ b/inc/spatial/intervalTree-private.hpp
@@ -1,0 +1,152 @@
+#include "intervalTree.hpp"
+
+template <typename T>
+IntervalTree<T>::IntervalTree():
+root_{new Node(std::numeric_limits<T>::min(), std::numeric_limits<T>::max())}, size_{0}
+{
+}
+
+template <typename T>
+IntervalTree<T>::~IntervalTree()
+{
+    destroyTree(root_);
+}
+
+template <typename T>
+void IntervalTree<T>::destroyTree(Node* n){
+    if (n){
+        if (n->left_){
+            destroyTree(n->left_);
+        }
+        if (n->right_){
+            destroyTree(n->right_);
+        }
+        delete n;
+    }
+}
+
+template <typename T>
+void IntervalTree<T>::insert(const T &low, const T &high){
+    // First check if both endpoints are in the tree before adding them
+    if (!allEndpoints_.contains(low)){
+        insertNode(low, root_);
+        allEndpoints_.insert(low);
+    }
+    if (!allEndpoints_.contains(high)){
+        insertNode(high, root_);
+        allEndpoints_.insert(high);
+    }
+    allIntervals_.push_back(Interval{low, high});
+    // Insert the INDEX of the interval into each node
+    insertInterval(size_, root_);
+    ++size_;
+    return;
+}
+
+template <typename T>
+void IntervalTree<T>::insert(const Interval& i){
+    insert(i.low_, i.high_);
+    return;
+}
+
+template <typename T>
+void IntervalTree<T>::insertNode(const T& value, Node*&node){
+    if (node->isLeaf_){
+        node->isLeaf_ = false;
+        node->value_ = value;
+        node->left_ = new Node(node->min_, value);
+        node->right_ = new Node(value, node->max_);
+    } else if (value > node->value_){
+        insertNode(value, node->right_);
+    } else {
+        insertNode(value, node->left_);
+    }
+}
+
+template <typename T>
+void IntervalTree<T>::insertInterval(size_t intervalInd, Node*&node){
+    const Interval &i = allIntervals_[intervalInd];
+    // Case where the node's subtree is fully contained in the interval
+    if (node->min_ >= i.low_ and node->max_ <= i.high_)
+    {
+        node->intervals_.push_back(intervalInd);
+    }
+    else
+    {
+        // Going to be using node->value_
+        // assert(!node->isLeaf_);
+        if (node->isLeaf_){
+            throw std::logic_error("Node cannot be a leaf here");
+        }
+        if (i.low_ < node->value_){
+            insertInterval(intervalInd, node->left_);
+        } 
+        if (node->value_ < i.high_){
+            insertInterval(intervalInd, node->right_);
+        }
+    }
+}
+
+template <typename T>
+void IntervalTree<T>::query(const T& queryPoint,std::unordered_set<size_t>& intervals, Node* n) const{
+    intervals.insert(n->intervals_.begin(), n->intervals_.end());
+    if (n->isLeaf_) {
+        return;
+    }  
+    // if queryPoint == n->value_, recurse on both sides.
+    if (queryPoint <= n->value_) {
+        query(queryPoint, intervals, n->left_);
+    } 
+    if (queryPoint >= n->value_) {
+        query(queryPoint, intervals, n->right_);
+    } 
+}
+
+template <typename T>
+std::vector<std::pair<T, T>> IntervalTree<T>::findOverlaps(const T& queryPoint){
+    std::unordered_set<size_t> overlapInds;
+    query(queryPoint, overlapInds,root_);
+    std::vector<std::pair<T, T>> overlapIntervals;
+    for (size_t intervalInd : overlapInds)
+    {
+        const Interval &i = allIntervals_[intervalInd];
+        overlapIntervals.push_back({i.low_, i.high_});
+    }
+    return overlapIntervals;
+}
+
+template <typename T>
+std::vector<std::pair<T, T>> IntervalTree<T>::findSupersets(const T &low, const T &high){
+    std::unordered_set<size_t> overlapLow;
+    std::unordered_set<size_t> overlapHigh;
+    query(low, overlapLow,root_);
+    query(high, overlapHigh,root_);
+    std::vector<std::pair<T, T>> overlapIntervals;
+    // Find Intersection of sets
+    for (size_t intervalInd : overlapHigh){
+        // Both contain this interval
+        if (overlapLow.contains(intervalInd)){
+            const Interval &i = allIntervals_[intervalInd];
+            overlapIntervals.push_back({i.low_, i.high_});
+        }
+    }
+    return overlapIntervals;
+}
+
+// Struct Functions
+
+template <typename T>
+IntervalTree<T>::Interval::Interval(T low, T high):
+    low_{low}, high_{high}{
+        // Nothing here
+}
+
+template<typename T>
+IntervalTree<T>::Node::Node(T min, T max):
+    left_{nullptr}, 
+    right_{nullptr}, 
+    min_{min},
+    max_{max}, 
+    isLeaf_{true}{
+        // Nothing to initialize
+}

--- a/inc/spatial/intervalTree.hpp
+++ b/inc/spatial/intervalTree.hpp
@@ -57,23 +57,23 @@ class Interval
 };
 
 
-template <typename T, Interval I>
+template <Interval I>
 class IntervalTree {
 
-  private:
+    using T = I::value_type;
       // Interval Tree Node Struct
-      struct Node
-      {
-          std::vector<size_t> intervals_; // Vector indexes of stored intervals
-          Node *left_;
-          Node *right_;
-          T value_;
-          T min_;       // Minimum value in subtree
-          T max_;       // Maximum value in subtree
-          bool isLeaf_; // Accessing value_ in leaf nodes is underfined
+    struct Node
+    {
+        std::vector<size_t> intervals_; // Vector indexes of stored intervals
+        Node *left_;
+        Node *right_;
+        T value_;
+        T min_;       // Minimum value in subtree
+        T max_;       // Maximum value in subtree
+        bool isLeaf_; // Accessing value_ in leaf nodes is underfined
 
-          // Constructors
-          Node(T min, T max);
+        // Constructors
+        Node(T min, T max);
     };
 
     // Tree Data

--- a/inc/spatial/intervalTree.hpp
+++ b/inc/spatial/intervalTree.hpp
@@ -15,36 +15,51 @@
 #include <tuple>
 #include <unordered_set>
 #include <numeric>
-// #include <concepts>
+#include <concepts>
 
 
-// template <typename I>
-// concept Interval = requires()
 template <typename IntervalType>
 concept Interval = requires(IntervalType &interval,
-                        const IntervalType::value_type v) {
-    // tree.insert(pair);
-    // iter = tree.find(key);
-    // iter = tree.begin();
-    // iter = tree.end();
-    // tree.operator[](key);
-    // tree.find(key);
-    // tree.clear();
-    // tree.erase(key);
+                            IntervalType::value_type v) {
+
+    interval = IntervalType(v, v);
     v = interval.low();
     v = interval.high();
-    // tree.insert(in, in);
-};
-
-namespace IntervalTree {
-    struct Interval;
 };
 
 
+
+namespace ITree {
+/**
+ * @brief Simple implementation of the Interval concept. Used for holding ranges of numbers. 
+ * 
+ */
 template <typename T>
-class IntervalTree {
+class Interval
+{
+    // Data
+    T low_;
+    T high_;
+
     public: 
-    struct Interval;
+
+    using value_type = T;
+    // Constructors / Destructor
+    Interval(T low, T high);
+    Interval(const Interval &other) = default;
+    ~Interval() = default;
+
+    T low() const {return low_;};
+    T high() const {return high_;}
+
+    bool operator==(const Interval& other) const;
+};
+};
+
+
+template <typename T, Interval I>
+class IntervalTree {
+
   private:
       // Interval Tree Node Struct
       struct Node
@@ -63,7 +78,7 @@ class IntervalTree {
 
     // Tree Data
     std::unordered_set<T> allEndpoints_; // Check if endpoint already exists
-    std::vector<Interval> allIntervals_; // Store all intervals here
+    std::vector<I> allIntervals_; // Store all intervals here
     Node *root_;
     size_t size_;
 
@@ -122,7 +137,7 @@ public:
      * 
      * @param i IntervalTree::Interval object to insert
      */
-    void insert(const Interval &i);
+    void insert(const I &i);
 
     /**
      * @brief Finds all intervals that overlap with a given query point
@@ -131,8 +146,7 @@ public:
      * @return std::vector<std::tuple<T, T>> Vector with low and high bounds
      * of all intervals that contain queryPoint param
      */
-    std::vector<std::pair<T, T>> findOverlaps(const T &queryPoint);
-
+    std::vector<I> findOverlaps(const T& queryPoint);
     /**
      * @brief Finds all intervals that fully contain the low and high bound
      * 
@@ -141,26 +155,9 @@ public:
      * @return std::vector<std::tuple<T, T>> Vector of all intervals that
      * fully contain the interval with lower bound low and upper bound high
      */
-    std::vector<std::pair<T, T>> findSupersets(const T &low, const T &high);
+    std::vector<I> findSupersets(const T &low, const T &high);
 
-    // Public Interval Struct
 
-    /**
-     * @brief Mostly for bookkeeping in implementation, but is public and can 
-     * be constructed and inserted into the interval tree
-     * 
-     */
-    struct Interval
-    {
-        // Data
-        T low_;
-        T high_;
-    
-        // Constructors / Destructor
-        Interval(T low, T high);
-        Interval(const Interval &other) = default;
-        ~Interval() = default;
-    };
 };
 
 #include "intervalTree-private.hpp"

--- a/inc/spatial/intervalTree.hpp
+++ b/inc/spatial/intervalTree.hpp
@@ -1,0 +1,166 @@
+/**
+ * @file intervalTree.hpp
+ * @author Ryan Butler (rbutler@g.hmc.edu)
+ * @brief Implementation of non-balancing interval tree
+ * @version 0.2
+ * @date 2023-07-21
+ * 
+ * @copyright Copyright (c) 2023
+ * 
+ */
+
+#pragma once
+
+#include <vector>
+#include <tuple>
+#include <unordered_set>
+#include <numeric>
+// #include <concepts>
+
+
+// template <typename I>
+// concept Interval = requires()
+template <typename IntervalType>
+concept Interval = requires(IntervalType &interval,
+                        const IntervalType::value_type v) {
+    // tree.insert(pair);
+    // iter = tree.find(key);
+    // iter = tree.begin();
+    // iter = tree.end();
+    // tree.operator[](key);
+    // tree.find(key);
+    // tree.clear();
+    // tree.erase(key);
+    v = interval.low();
+    v = interval.high();
+    // tree.insert(in, in);
+};
+
+namespace IntervalTree {
+    struct Interval;
+};
+
+
+template <typename T>
+class IntervalTree {
+    public: 
+    struct Interval;
+  private:
+      // Interval Tree Node Struct
+      struct Node
+      {
+          std::vector<size_t> intervals_; // Vector indexes of stored intervals
+          Node *left_;
+          Node *right_;
+          T value_;
+          T min_;       // Minimum value in subtree
+          T max_;       // Maximum value in subtree
+          bool isLeaf_; // Accessing value_ in leaf nodes is underfined
+
+          // Constructors
+          Node(T min, T max);
+    };
+
+    // Tree Data
+    std::unordered_set<T> allEndpoints_; // Check if endpoint already exists
+    std::vector<Interval> allIntervals_; // Store all intervals here
+    Node *root_;
+    size_t size_;
+
+    // Helper Functions:
+
+    /**
+     * @brief Helper function for destructor
+     * 
+     * @param node Node to destroy
+     */
+    void destroyTree(Node *node);
+
+    /**
+     * @brief Inserts a new node into the tree representing an endpoint
+     * 
+     * @param value Value to put in the node
+     * @param node Current node 
+     */
+    void insertNode(const T& value, Node *&node);
+
+    /**
+     * @brief Inserts an interval into the tree
+     * 
+     * @param intervalInd Index of this interval in allIntervals_ vector
+     * @param node Current node
+     */
+    void insertInterval(size_t intervalInd, Node*& node);
+
+    /**
+     * @brief Helper function for finding overlapping intervals
+     * 
+     * @param queryPoint Point to find overlaps for
+     * @param intervals Set of interval indexes. Modified over time
+     * @param n Current node
+     */
+    void query(const T &queryPoint, std::unordered_set<size_t>& intervals, Node* n) const;
+
+public:
+
+    // Constructors
+    IntervalTree();
+    ~IntervalTree();
+
+    // Interface Functions:
+
+    /**
+     * @brief Inserts an interval into the interval tree
+     * 
+     * @param low Lower bound of interval
+     * @param high Upper bound of interval
+     */
+    void insert(const T &low, const T &high);
+
+    /**
+     * @brief Overloaded insert function
+     * 
+     * @param i IntervalTree::Interval object to insert
+     */
+    void insert(const Interval &i);
+
+    /**
+     * @brief Finds all intervals that overlap with a given query point
+     * 
+     * @param queryPoint Value that overlaps with every interval returned
+     * @return std::vector<std::tuple<T, T>> Vector with low and high bounds
+     * of all intervals that contain queryPoint param
+     */
+    std::vector<std::pair<T, T>> findOverlaps(const T &queryPoint);
+
+    /**
+     * @brief Finds all intervals that fully contain the low and high bound
+     * 
+     * @param low lower bound of interval
+     * @param high upper bound 
+     * @return std::vector<std::tuple<T, T>> Vector of all intervals that
+     * fully contain the interval with lower bound low and upper bound high
+     */
+    std::vector<std::pair<T, T>> findSupersets(const T &low, const T &high);
+
+    // Public Interval Struct
+
+    /**
+     * @brief Mostly for bookkeeping in implementation, but is public and can 
+     * be constructed and inserted into the interval tree
+     * 
+     */
+    struct Interval
+    {
+        // Data
+        T low_;
+        T high_;
+    
+        // Constructors / Destructor
+        Interval(T low, T high);
+        Interval(const Interval &other) = default;
+        ~Interval() = default;
+    };
+};
+
+#include "intervalTree-private.hpp"

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -3,27 +3,22 @@ cmake_minimum_required(VERSION 4.0.0)
 add_subdirectory(googletest)
 include(GoogleTest)
 
-string(TOUPPER ${CMAKE_BUILD_TYPE} buildType)
+add_compile_options($<$<CONFIG:Debug>:-fsanitize=address>)
+add_link_options($<$<CONFIG:Debug>:-fsanitize=address>)
 
-if (buildType STREQUAL "DEBUG")
-    add_compile_options(-fsanitize=address)
-    add_link_options(-fsanitize=address)
-
-    add_compile_options(-fsanitize=undefined)
-    add_link_options(-fsanitize=undefined)
-    message("-- Debug Mode: Enabling address and undefined behavior sanitizers")
-endif()
+add_compile_options($<$<CONFIG:Debug>:-fsanitize=undefined>)
+add_link_options($<$<CONFIG:Debug>:-fsanitize=undefined>)
 
 
 macro (DS_add_test testname src)
     add_executable("${testname}Test" ${src})
-    target_link_libraries("${testname}Test" PRIVATE GTest::gtest)
+    target_link_libraries("${testname}Test" PRIVATE GTest::gtest GTest::gtest_main)
     gtest_discover_tests("${testname}Test")
 endmacro()
 
 macro(add_typed_test testname src)
     add_executable("${testname}Test" ${src})
-    target_link_libraries("${testname}Test" PRIVATE GTest::gtest)
+    target_link_libraries("${testname}Test" PRIVATE GTest::gtest GTest::gtest_main)
     gtest_discover_tests("${testname}Test" TEST_LIST .TYPED)
 endmacro()
 
@@ -33,7 +28,7 @@ add_executable(launching-threadpool launching-threadpool-test.cpp)
 
 # KD Tree test requires gmock
 add_executable(kdtreeTest kdtree-test.cpp)
-target_link_libraries(kdtreeTest gtest gmock)
+target_link_libraries(kdtreeTest GTest::gtest GTest::gmock GTest::gtest_main)
 gtest_discover_tests(kdtreeTest)
 
 
@@ -41,5 +36,6 @@ DS_add_test(unrolled-ll ULL-test.cpp)
 DS_add_test(splay-tree splay-tree-test.cpp)
 DS_add_test(scapegoat-tree scapegoat-test.cpp)
 DS_add_test(median median-test.cpp)
+DS_add_test(interval-tree intervalTree-test.cpp)
 add_typed_test(tree tree-test.cpp)
 add_typed_test(heap heap-test.cpp)

--- a/tests/ULL-test.cpp
+++ b/tests/ULL-test.cpp
@@ -325,9 +325,3 @@ TEST(UnrolledLinkedList, compareList){
     std::vector<int> v = toVec(ull);
     ASSERT_TRUE(std::ranges::equal(v, ll));
 }
-
-int main(int argc, char** argv){
-    ::testing::InitGoogleTest(&argc, argv);
-    return RUN_ALL_TESTS();
-
-}

--- a/tests/heap-test.cpp
+++ b/tests/heap-test.cpp
@@ -193,8 +193,3 @@ TYPED_TEST(HeapTest, changeKey2){
     this->heap_.changeKey(10, 4);
     
 }
-
-int main(int argc, char** argv){
-    ::testing::InitGoogleTest(&argc, argv);
-    return RUN_ALL_TESTS();
-}

--- a/tests/intervalTree-test.cpp
+++ b/tests/intervalTree-test.cpp
@@ -6,7 +6,7 @@
 class IntervalTreeTest : public ::testing::Test {
 
     protected:
-    IntervalTree<int, ITree::Interval<int>> itree_;
+    IntervalTree<ITree::Interval<int>> itree_;
 
     void SetUp() override {
         int min = std::numeric_limits<int>::min();

--- a/tests/intervalTree-test.cpp
+++ b/tests/intervalTree-test.cpp
@@ -6,7 +6,7 @@
 class IntervalTreeTest : public ::testing::Test {
 
     protected:
-    IntervalTree<int> itree_;
+    IntervalTree<int, ITree::Interval<int>> itree_;
 
     void SetUp() override {
         int min = std::numeric_limits<int>::min();
@@ -14,9 +14,8 @@ class IntervalTreeTest : public ::testing::Test {
         int lowerBounds[] = {10, 15, 18, 12, 21, 9, 17, 30, 19, 12, min};
         int upperBounds[] = {20, 25, 22, 22,23,15,20,40,20,13, max};
 
-        std::vector<IntervalTree<int>::Interval> intervals;
         for (size_t i = 0; i < 11; ++i) {
-            IntervalTree<int>::Interval bounds {lowerBounds[i], upperBounds[i]};
+            ITree::Interval<int> bounds {lowerBounds[i], upperBounds[i]};
             itree_.insert(bounds);
         }
     }
@@ -24,25 +23,25 @@ class IntervalTreeTest : public ::testing::Test {
 };
 
 TEST_F(IntervalTreeTest, Query){
-    std::vector<std::pair<int, int>> overlaps = itree_.findOverlaps(13);
+    std::vector<ITree::Interval<int>> overlaps = itree_.findOverlaps(13);
     ASSERT_EQ(overlaps.size(), 5);
-    EXPECT_EQ(overlaps[0], std::make_pair(12, 13));
-    EXPECT_EQ(overlaps[1], std::make_pair(12, 22));
-    EXPECT_EQ(overlaps[2], std::make_pair(9, 15));
-    EXPECT_EQ(overlaps[3], std::make_pair(10, 20));
-    EXPECT_EQ(overlaps[4], std::make_pair(-2147483648, 2147483647));
+    EXPECT_EQ(overlaps[0], ITree::Interval<int>(12, 13));
+    EXPECT_EQ(overlaps[1], ITree::Interval<int>(12, 22));
+    EXPECT_EQ(overlaps[2], ITree::Interval<int>(9, 15));
+    EXPECT_EQ(overlaps[3], ITree::Interval<int>(10, 20));
+    EXPECT_EQ(overlaps[4], ITree::Interval<int>(-2147483648, 2147483647));
 }
 
 TEST_F(IntervalTreeTest, Supersets){
-    std::vector<std::pair<int, int>> supersets = itree_.findSupersets(17, 21);
+    std::vector<ITree::Interval<int>> supersets = itree_.findSupersets(17, 21);
     ASSERT_EQ(supersets.size(), 3);
-    EXPECT_EQ(supersets[0], std::make_pair(12, 22));
-    EXPECT_EQ(supersets[1], std::make_pair(15, 25));
-    EXPECT_EQ(supersets[2], std::make_pair(-2147483648, 2147483647));
+    EXPECT_EQ(supersets[0], ITree::Interval<int>(12, 22));
+    EXPECT_EQ(supersets[1], ITree::Interval<int>(15, 25));
+    EXPECT_EQ(supersets[2], ITree::Interval<int>(-2147483648, 2147483647));
 }
 
 TEST_F(IntervalTreeTest, SupersetsMax){
-    std::vector<std::pair<int, int>> supersets = itree_.findSupersets(-2147483648, 2147483647);
+    std::vector<ITree::Interval<int>> supersets = itree_.findSupersets(-2147483648, 2147483647);
     ASSERT_EQ(supersets.size(), 1);
-    EXPECT_EQ(supersets[0], std::make_pair(-2147483648, 2147483647));
+    EXPECT_EQ(supersets[0], ITree::Interval<int>(-2147483648, 2147483647));
 }

--- a/tests/intervalTree-test.cpp
+++ b/tests/intervalTree-test.cpp
@@ -1,7 +1,27 @@
 #include "spatial/intervalTree.hpp"
 #include <iostream>
+#include <algorithm>
+#include <ranges>
 #include <gtest/gtest.h>
 
+
+// Interval that holds some data
+class IntervalWithMidpoint : public ITree::Interval<float>{
+    // Data
+    float midpoint_;
+
+    public: 
+
+    IntervalWithMidpoint(float low, float high):
+        ITree::Interval<float>(low, high), 
+        midpoint_{static_cast<float>((high + low)/ 2.0)}{}
+    IntervalWithMidpoint(float low, float high, float data):
+        ITree::Interval<float>(low, high), midpoint_{data}{}
+    IntervalWithMidpoint(const IntervalWithMidpoint &other) = default;
+    ~IntervalWithMidpoint() = default;
+    float midpoint() const {return midpoint_;}
+    bool operator==(const IntervalWithMidpoint& other) const = default;
+};
 
 class IntervalTreeTest : public ::testing::Test {
 
@@ -44,4 +64,29 @@ TEST_F(IntervalTreeTest, SupersetsMax){
     std::vector<ITree::Interval<int>> supersets = itree_.findSupersets(-2147483648, 2147483647);
     ASSERT_EQ(supersets.size(), 1);
     EXPECT_EQ(supersets[0], ITree::Interval<int>(-2147483648, 2147483647));
+}
+
+class IntervalTreeWithData : public ::testing::Test {
+    protected:  
+    IntervalTree<IntervalWithMidpoint> itree_;
+
+    void SetUp() override {
+        std::array<float, 9> lower{1.1,  1.5, 1.8, 1.2, 2.1, 9.25, 17.5, 30.5, 18.1};
+        std::array<float, 9> upper{2.02, 2.5, 2.2, 2.2, 2.3, 15.1, 20.9, 38.2, 20.6};
+        std::array<float, 9> data {1.56, 2.0, 2.0, 1.6, 2.2,12.175,19.2,34.35,19.35};
+        for (size_t i = 0; i < 9; ++i) {
+            IntervalWithMidpoint bounds{lower[i], upper[i], data[i]};
+            itree_.insert(bounds);
+        }
+    }
+};
+
+TEST_F(IntervalTreeWithData, testData){
+    std::vector<IntervalWithMidpoint> intervals = itree_.findOverlaps(2.0);
+    ASSERT_EQ(intervals.size(), 4);
+    std::vector<float> midpoints;
+    std::transform(intervals.begin(), intervals.end(), std::back_inserter(midpoints), 
+    [](const IntervalWithMidpoint& i){return i.midpoint();});
+    std::ranges::sort(midpoints);
+    ASSERT_EQ(midpoints, std::vector<float>({1.56, 1.6, 2.0, 2.0}));
 }

--- a/tests/intervalTree-test.cpp
+++ b/tests/intervalTree-test.cpp
@@ -1,0 +1,48 @@
+#include "spatial/intervalTree.hpp"
+#include <iostream>
+#include <gtest/gtest.h>
+
+
+class IntervalTreeTest : public ::testing::Test {
+
+    protected:
+    IntervalTree<int> itree_;
+
+    void SetUp() override {
+        int min = std::numeric_limits<int>::min();
+        int max = std::numeric_limits<int>::max();
+        int lowerBounds[] = {10, 15, 18, 12, 21, 9, 17, 30, 19, 12, min};
+        int upperBounds[] = {20, 25, 22, 22,23,15,20,40,20,13, max};
+
+        std::vector<IntervalTree<int>::Interval> intervals;
+        for (size_t i = 0; i < 11; ++i) {
+            IntervalTree<int>::Interval bounds {lowerBounds[i], upperBounds[i]};
+            itree_.insert(bounds);
+        }
+    }
+
+};
+
+TEST_F(IntervalTreeTest, Query){
+    std::vector<std::pair<int, int>> overlaps = itree_.findOverlaps(13);
+    ASSERT_EQ(overlaps.size(), 5);
+    EXPECT_EQ(overlaps[0], std::make_pair(12, 13));
+    EXPECT_EQ(overlaps[1], std::make_pair(12, 22));
+    EXPECT_EQ(overlaps[2], std::make_pair(9, 15));
+    EXPECT_EQ(overlaps[3], std::make_pair(10, 20));
+    EXPECT_EQ(overlaps[4], std::make_pair(-2147483648, 2147483647));
+}
+
+TEST_F(IntervalTreeTest, Supersets){
+    std::vector<std::pair<int, int>> supersets = itree_.findSupersets(17, 21);
+    ASSERT_EQ(supersets.size(), 3);
+    EXPECT_EQ(supersets[0], std::make_pair(12, 22));
+    EXPECT_EQ(supersets[1], std::make_pair(15, 25));
+    EXPECT_EQ(supersets[2], std::make_pair(-2147483648, 2147483647));
+}
+
+TEST_F(IntervalTreeTest, SupersetsMax){
+    std::vector<std::pair<int, int>> supersets = itree_.findSupersets(-2147483648, 2147483647);
+    ASSERT_EQ(supersets.size(), 1);
+    EXPECT_EQ(supersets[0], std::make_pair(-2147483648, 2147483647));
+}

--- a/tests/kdtree-test.cpp
+++ b/tests/kdtree-test.cpp
@@ -405,8 +405,3 @@ TEST_P(KDTreeTest, BoundingBoxQuery){
 INSTANTIATE_TEST_SUITE_P(KDFuzzTest,
     KDTreeTest,
     testing::Values(100, 1000, 5000));
-
-int main(){
-    ::testing::InitGoogleTest();
-    return RUN_ALL_TESTS();
-}

--- a/tests/median-test.cpp
+++ b/tests/median-test.cpp
@@ -13,8 +13,3 @@ TEST(MedianHeapTest, insertion){
         ASSERT_EQ(h.findMedian(), medians[i]);
     }
 }
-
-int main(int argc, char** argv){
-    ::testing::InitGoogleTest(&argc, argv);
-    return RUN_ALL_TESTS();
-}

--- a/tests/scapegoat-test.cpp
+++ b/tests/scapegoat-test.cpp
@@ -60,9 +60,3 @@ TEST(Scapegoat, reshuffle2){
     }
     // cout << sg << endl;
 }
-
-
-int main(){
-    testing::InitGoogleTest();
-    return RUN_ALL_TESTS();
-}

--- a/tests/splay-tree-test.cpp
+++ b/tests/splay-tree-test.cpp
@@ -111,8 +111,3 @@ TEST(SplayTreeTest, destructor){
         ASSERT_EQ(st[key],correct[key]);
     }
 }
-
-int main(int argc, char** argv){
-    ::testing::InitGoogleTest(&argc, argv);
-    return RUN_ALL_TESTS();
-}

--- a/tests/tree-test.cpp
+++ b/tests/tree-test.cpp
@@ -149,8 +149,3 @@ TYPED_TEST(TreeTest, largeSortedInput){
         this->tree_.insert({i, i+100});
     }
 }
-
-int main(){
-    ::testing::InitGoogleTest();
-    return RUN_ALL_TESTS();
-}


### PR DESCRIPTION
Adds the interval tree. This is a significant deviation over my summer 2023 implementation since it is templated based on the Interval _concept_ rather than a typename T. This allows for more flexible intervals including ones that store data. This PR also adds gtest_main to all the google tests and removes the boilerplate at the end of each test file.  The interval tree test now has a google test framework to test it rather than a script that prints out results.  Matplotplusplus is also fully removed as a submodule since it was not being used and was making the build fail. 