### PR TITLE
Interval tre improvements

### DIFF
--- a/inc/spatial/intervalTree-private.hpp
+++ b/inc/spatial/intervalTree-private.hpp
@@ -98,21 +98,6 @@ void IntervalTree<I>::insertInterval(size_t intervalInd, Node*&node){
 }
 
 template <Interval I>
-void IntervalTree<I>::query(const T& queryPoint,std::unordered_set<size_t>& intervals, Node* n) const{
-    intervals.insert(n->intervals_.begin(), n->intervals_.end());
-    if (n->isLeaf_) {
-        return;
-    }  
-    // if queryPoint == n->value_, recurse on both sides.
-    if (queryPoint <= n->value_) {
-        query(queryPoint, intervals, n->left_);
-    } 
-    if (queryPoint >= n->value_) {
-        query(queryPoint, intervals, n->right_);
-    } 
-}
-
-template <Interval I>
 void IntervalTree<I>::query(const I& interval,std::unordered_set<size_t>& intervals, Node* n) const{
     intervals.insert(n->intervals_.begin(), n->intervals_.end());
     if (n->isLeaf_) {
@@ -136,7 +121,8 @@ void IntervalTree<I>::query(const I& interval,std::unordered_set<size_t>& interv
 template <Interval I>
 std::vector<I> IntervalTree<I>::findOverlaps(const T& queryPoint){
     std::unordered_set<size_t> overlapInds;
-    query(queryPoint, overlapInds,root_);
+    query({queryPoint, queryPoint}, overlapInds, root_);
+
     std::vector<I> overlapIntervals;
     for (size_t intervalInd : overlapInds)
     {
@@ -161,8 +147,8 @@ template <Interval I>
 std::vector<I> IntervalTree<I>::findSupersets(const T &low, const T &high){
     std::unordered_set<size_t> overlapLow;
     std::unordered_set<size_t> overlapHigh;
-    query(low, overlapLow, root_);
-    query(high, overlapHigh, root_);
+    query({low, low}, overlapLow, root_);
+    query({high, high}, overlapHigh, root_);
     std::vector<I> overlapIntervals;
     // Find Intersection of sets
     for (size_t intervalInd : overlapHigh){

--- a/inc/spatial/intervalTree-private.hpp
+++ b/inc/spatial/intervalTree-private.hpp
@@ -26,6 +26,15 @@ void IntervalTree<I>::destroyTree(Node* n){
 }
 
 template <Interval I>
+void IntervalTree<I>::clear(){
+    destroyTree(root_);
+    root_ = new Node(std::numeric_limits<T>::min(), std::numeric_limits<T>::max());
+    allEndpoints_.clear();
+    allIntervals_.clear();
+    size_ = 0;
+}
+
+template <Interval I>
 void IntervalTree<I>::insert(const T &low, const T &high){
     insert(I{low, high});
 }
@@ -104,7 +113,40 @@ void IntervalTree<I>::query(const T& queryPoint,std::unordered_set<size_t>& inte
 }
 
 template <Interval I>
+void IntervalTree<I>::query(const I& interval,std::unordered_set<size_t>& intervals, Node* n) const{
+    intervals.insert(n->intervals_.begin(), n->intervals_.end());
+    if (n->isLeaf_) {
+        return;
+    }
+    // If query upper bound is less than current node value, intervals will be in left subtree
+    if (interval.high() < n->value_){
+        query(interval, intervals, n->left_);
+    }
+    // If query lower bound is greater than node value, intervals will be in right subtree
+    if (interval.low() > n->value_){
+        query(interval, intervals, n->right_);
+    }
+
+    // If node value is INSIDE the interval or on the endpoints, recurse on both sides
+    if (interval.low() <= n->value_ and interval.high() >= n->value_){
+        query(interval, intervals, n->left_);
+        query(interval, intervals, n->right_);
+    }
+}
+template <Interval I>
 std::vector<I> IntervalTree<I>::findOverlaps(const T& queryPoint){
+    std::unordered_set<size_t> overlapInds;
+    query(queryPoint, overlapInds,root_);
+    std::vector<I> overlapIntervals;
+    for (size_t intervalInd : overlapInds)
+    {
+        overlapIntervals.push_back(allIntervals_[intervalInd]);
+    }
+    return overlapIntervals;
+}
+
+template <Interval I>
+std::vector<I> IntervalTree<I>::findOverlaps(const I& queryPoint){
     std::unordered_set<size_t> overlapInds;
     query(queryPoint, overlapInds,root_);
     std::vector<I> overlapIntervals;

--- a/inc/spatial/intervalTree-private.hpp
+++ b/inc/spatial/intervalTree-private.hpp
@@ -135,13 +135,13 @@ std::vector<I> IntervalTree<I>::findSupersets(const T &low, const T &high){
 // Struct Functions
 
 template <typename T>
-ITree::Interval<T>::Interval(T low, T high):
+SimpleInterval<T>::SimpleInterval(T low, T high):
     low_{low}, high_{high}{
         // Nothing here
 }
 
 template <typename T>
-bool ITree::Interval<T>::operator==(const Interval<T>& other) const {
+bool SimpleInterval<T>::operator==(const SimpleInterval<T>& other) const {
     return (low_ == other.low_) && (high_ == other.high_);
 }
 

--- a/inc/spatial/intervalTree.hpp
+++ b/inc/spatial/intervalTree.hpp
@@ -114,6 +114,7 @@ class IntervalTree {
      */
     void query(const T &queryPoint, std::unordered_set<size_t>& intervals, Node* n) const;
 
+    void query(const I& interval, std::unordered_set<size_t>& intervals, Node* n) const;
 public:
 
     // Constructors
@@ -121,6 +122,12 @@ public:
     ~IntervalTree();
 
     // Interface Functions:
+
+    /**
+     * @brief Clears the interval tree
+     * 
+     */
+    void clear();
 
     /**
      * @brief Inserts an interval into the interval tree
@@ -145,6 +152,15 @@ public:
      * of all intervals that contain queryPoint param
      */
     std::vector<I> findOverlaps(const T& queryPoint);
+
+    /**
+     * @brief Range Query: Finds all intervals that overlap with the given interval. 
+     * 
+     * @param interval Interval to find intervals overlapping
+     * @return std::vector<I> Vector to return the overlapping intervals. Not gauranteed sorted in any order. 
+     */
+    std::vector<I> findOverlaps(const I& interval);
+
     /**
      * @brief Finds all intervals that fully contain the low and high bound
      * 

--- a/inc/spatial/intervalTree.hpp
+++ b/inc/spatial/intervalTree.hpp
@@ -106,14 +106,12 @@ class IntervalTree {
     void insertInterval(size_t intervalInd, Node*& node);
 
     /**
-     * @brief Helper function for finding overlapping intervals
+     * @brief Recursive helper function for finding overlapping intervals
      * 
-     * @param queryPoint Point to find overlaps for
+     * @param interval Interval to find overlaps for
      * @param intervals Set of interval indexes. Modified over time
      * @param n Current node
      */
-    void query(const T &queryPoint, std::unordered_set<size_t>& intervals, Node* n) const;
-
     void query(const I& interval, std::unordered_set<size_t>& intervals, Node* n) const;
 public:
 

--- a/inc/spatial/intervalTree.hpp
+++ b/inc/spatial/intervalTree.hpp
@@ -29,13 +29,12 @@ concept Interval = requires(IntervalType &interval,
 
 
 
-namespace ITree {
 /**
  * @brief Simple implementation of the Interval concept. Used for holding ranges of numbers. 
  * 
  */
 template <typename T>
-class Interval
+class SimpleInterval
 {
     // Data
     T low_;
@@ -45,15 +44,14 @@ class Interval
 
     using value_type = T;
     // Constructors / Destructor
-    Interval(T low, T high);
-    Interval(const Interval &other) = default;
-    ~Interval() = default;
+    SimpleInterval(T low, T high);
+    SimpleInterval(const SimpleInterval &other) = default;
+    virtual ~SimpleInterval() = default;
 
     T low() const {return low_;};
     T high() const {return high_;}
 
-    bool operator==(const Interval& other) const;
-};
+    bool operator==(const SimpleInterval& other) const;
 };
 
 

--- a/tests/intervalTree-test.cpp
+++ b/tests/intervalTree-test.cpp
@@ -4,12 +4,24 @@
 #include <ranges>
 #include <gtest/gtest.h>
 
+namespace {
+    template <typename T>
+    void sortIntervals(std::vector<SimpleInterval<T>>& intervals){
+        auto compareFunc = [](const auto& i1, const auto& i2){
+            if (i1.low() == i2.low()){
+                return i1.high() < i2.high();
+            } else {
+                return i1.low() < i2.low();
+            }
+        };
+        std::ranges::sort(intervals, compareFunc);
+    }
+} // anonymous namespace
 
-// Interval that holds some data
+// Interval that holds its midpoint
 class IntervalWithMidpoint : public SimpleInterval<float>{
     // Data
     float midpoint_;
-
     public: 
 
     IntervalWithMidpoint(float low, float high):
@@ -27,12 +39,14 @@ class IntervalTreeTest : public ::testing::Test {
 
     protected:
     IntervalTree<SimpleInterval<int>> itree_;
+    int min_;
+    int max_;
 
     void SetUp() override {
-        int min = std::numeric_limits<int>::min();
-        int max = std::numeric_limits<int>::max();
-        int lowerBounds[] = {10, 15, 18, 12, 21, 9, 17, 30, 19, 12, min};
-        int upperBounds[] = {20, 25, 22, 22,23,15,20,40,20,13, max};
+        min_ = std::numeric_limits<int>::min();
+        max_ = std::numeric_limits<int>::max();
+        std::array<int, 11> lowerBounds = {10, 15, 18, 12, 21,  9, 17, 30, 19, 12, min_};
+        std::array<int, 11> upperBounds = {20, 25, 22, 22, 23, 15, 20, 40, 20, 13, max_};
 
         for (size_t i = 0; i < 11; ++i) {
             SimpleInterval<int> bounds {lowerBounds[i], upperBounds[i]};
@@ -49,7 +63,7 @@ TEST_F(IntervalTreeTest, Query){
     EXPECT_EQ(overlaps[1], SimpleInterval<int>(12, 22));
     EXPECT_EQ(overlaps[2], SimpleInterval<int>(9, 15));
     EXPECT_EQ(overlaps[3], SimpleInterval<int>(10, 20));
-    EXPECT_EQ(overlaps[4], SimpleInterval<int>(-2147483648, 2147483647));
+    EXPECT_EQ(overlaps[4], SimpleInterval<int>(min_, max_));
 }
 
 TEST_F(IntervalTreeTest, Supersets){
@@ -57,13 +71,41 @@ TEST_F(IntervalTreeTest, Supersets){
     ASSERT_EQ(supersets.size(), 3);
     EXPECT_EQ(supersets[0], SimpleInterval<int>(12, 22));
     EXPECT_EQ(supersets[1], SimpleInterval<int>(15, 25));
-    EXPECT_EQ(supersets[2], SimpleInterval<int>(-2147483648, 2147483647));
+    EXPECT_EQ(supersets[2], SimpleInterval<int>(min_, max_));
 }
 
 TEST_F(IntervalTreeTest, SupersetsMax){
-    std::vector<SimpleInterval<int>> supersets = itree_.findSupersets(-2147483648, 2147483647);
+    std::vector<SimpleInterval<int>> supersets = itree_.findSupersets(min_, max_);
     ASSERT_EQ(supersets.size(), 1);
-    EXPECT_EQ(supersets[0], SimpleInterval<int>(-2147483648, 2147483647));
+    EXPECT_EQ(supersets[0], SimpleInterval<int>(min_, max_));
+}
+
+TEST_F(IntervalTreeTest, RangeQuery){
+    itree_.clear();
+    itree_.insert({1874,1951});
+    itree_.insert({1779,1828});
+    itree_.insert({1585,1672});
+    itree_.insert({1843,1907});
+    itree_.insert({1888,1971});
+    itree_.insert({1756,1791});
+
+    std::vector<SimpleInterval<int>> intervals = itree_.findOverlaps({1755, 1830});
+    ASSERT_EQ(intervals.size(), 2);
+    EXPECT_EQ(intervals[0], SimpleInterval<int>(1779, 1828));
+    EXPECT_EQ(intervals[1], SimpleInterval<int>(1756, 1791));
+}
+
+TEST_F(IntervalTreeTest, RangeQuery2){
+    std::vector<SimpleInterval<int>> intervals = itree_.findOverlaps({17, 21});
+    sortIntervals(intervals);
+    ASSERT_EQ(intervals.size(), 8);
+    std::array<int, 8> lower = {min_, 10, 12, 15, 17, 18, 19, 21}; // 21
+    std::array<int, 8> upper = {max_, 20, 22, 25, 20, 22, 20, 23}; // 23
+    for (int i : std::views::iota(0, 8)){
+        // std::cout << intervals[i].low() << " " << intervals[i].high() << std::endl;
+        EXPECT_EQ(intervals[i], SimpleInterval<int>(lower[i], upper[i]));
+    }
+
 }
 
 class IntervalTreeWithData : public ::testing::Test {
@@ -88,7 +130,7 @@ TEST_F(IntervalTreeWithData, testData){
     std::transform(intervals.begin(), intervals.end(), std::back_inserter(midpoints), 
     [](const IntervalWithMidpoint& i){return i.midpoint();});
     std::ranges::sort(midpoints);
-    ASSERT_EQ(midpoints, std::vector<float>({1.56, 1.6, 2.0, 2.0}));
+    EXPECT_EQ(midpoints, std::vector<float>({1.56, 1.6, 2.0, 2.0}));
 }
 
 TEST_F(IntervalTreeWithData, duplicateIntervals){
@@ -100,10 +142,12 @@ TEST_F(IntervalTreeWithData, duplicateIntervals){
     std::transform(intervals.begin(), intervals.end(), std::back_inserter(midpoints), 
     [](const IntervalWithMidpoint& i){return i.midpoint();});
     std::ranges::sort(midpoints);
+    EXPECT_EQ(midpoints, std::vector<float>({1.56, 1.6, 2.0, 2.0, 3.0}));
+
 }
 
-TEST(DuplicateData, duplicateIntervals2){
-    IntervalTree<IntervalWithMidpoint> itree_;
+TEST_F(IntervalTreeWithData, duplicateIntervals2){
+    itree_.clear();
     itree_.insert({0, 20, 0});
     itree_.insert({50, 80, 0});
     itree_.insert({0, 55, 1});

--- a/tests/intervalTree-test.cpp
+++ b/tests/intervalTree-test.cpp
@@ -6,17 +6,17 @@
 
 
 // Interval that holds some data
-class IntervalWithMidpoint : public ITree::Interval<float>{
+class IntervalWithMidpoint : public SimpleInterval<float>{
     // Data
     float midpoint_;
 
     public: 
 
     IntervalWithMidpoint(float low, float high):
-        ITree::Interval<float>(low, high), 
+        SimpleInterval<float>(low, high), 
         midpoint_{static_cast<float>((high + low)/ 2.0)}{}
     IntervalWithMidpoint(float low, float high, float data):
-        ITree::Interval<float>(low, high), midpoint_{data}{}
+        SimpleInterval<float>(low, high), midpoint_{data}{}
     IntervalWithMidpoint(const IntervalWithMidpoint &other) = default;
     ~IntervalWithMidpoint() = default;
     float midpoint() const {return midpoint_;}
@@ -26,7 +26,7 @@ class IntervalWithMidpoint : public ITree::Interval<float>{
 class IntervalTreeTest : public ::testing::Test {
 
     protected:
-    IntervalTree<ITree::Interval<int>> itree_;
+    IntervalTree<SimpleInterval<int>> itree_;
 
     void SetUp() override {
         int min = std::numeric_limits<int>::min();
@@ -35,7 +35,7 @@ class IntervalTreeTest : public ::testing::Test {
         int upperBounds[] = {20, 25, 22, 22,23,15,20,40,20,13, max};
 
         for (size_t i = 0; i < 11; ++i) {
-            ITree::Interval<int> bounds {lowerBounds[i], upperBounds[i]};
+            SimpleInterval<int> bounds {lowerBounds[i], upperBounds[i]};
             itree_.insert(bounds);
         }
     }
@@ -43,27 +43,27 @@ class IntervalTreeTest : public ::testing::Test {
 };
 
 TEST_F(IntervalTreeTest, Query){
-    std::vector<ITree::Interval<int>> overlaps = itree_.findOverlaps(13);
+    std::vector<SimpleInterval<int>> overlaps = itree_.findOverlaps(13);
     ASSERT_EQ(overlaps.size(), 5);
-    EXPECT_EQ(overlaps[0], ITree::Interval<int>(12, 13));
-    EXPECT_EQ(overlaps[1], ITree::Interval<int>(12, 22));
-    EXPECT_EQ(overlaps[2], ITree::Interval<int>(9, 15));
-    EXPECT_EQ(overlaps[3], ITree::Interval<int>(10, 20));
-    EXPECT_EQ(overlaps[4], ITree::Interval<int>(-2147483648, 2147483647));
+    EXPECT_EQ(overlaps[0], SimpleInterval<int>(12, 13));
+    EXPECT_EQ(overlaps[1], SimpleInterval<int>(12, 22));
+    EXPECT_EQ(overlaps[2], SimpleInterval<int>(9, 15));
+    EXPECT_EQ(overlaps[3], SimpleInterval<int>(10, 20));
+    EXPECT_EQ(overlaps[4], SimpleInterval<int>(-2147483648, 2147483647));
 }
 
 TEST_F(IntervalTreeTest, Supersets){
-    std::vector<ITree::Interval<int>> supersets = itree_.findSupersets(17, 21);
+    std::vector<SimpleInterval<int>> supersets = itree_.findSupersets(17, 21);
     ASSERT_EQ(supersets.size(), 3);
-    EXPECT_EQ(supersets[0], ITree::Interval<int>(12, 22));
-    EXPECT_EQ(supersets[1], ITree::Interval<int>(15, 25));
-    EXPECT_EQ(supersets[2], ITree::Interval<int>(-2147483648, 2147483647));
+    EXPECT_EQ(supersets[0], SimpleInterval<int>(12, 22));
+    EXPECT_EQ(supersets[1], SimpleInterval<int>(15, 25));
+    EXPECT_EQ(supersets[2], SimpleInterval<int>(-2147483648, 2147483647));
 }
 
 TEST_F(IntervalTreeTest, SupersetsMax){
-    std::vector<ITree::Interval<int>> supersets = itree_.findSupersets(-2147483648, 2147483647);
+    std::vector<SimpleInterval<int>> supersets = itree_.findSupersets(-2147483648, 2147483647);
     ASSERT_EQ(supersets.size(), 1);
-    EXPECT_EQ(supersets[0], ITree::Interval<int>(-2147483648, 2147483647));
+    EXPECT_EQ(supersets[0], SimpleInterval<int>(-2147483648, 2147483647));
 }
 
 class IntervalTreeWithData : public ::testing::Test {
@@ -89,4 +89,39 @@ TEST_F(IntervalTreeWithData, testData){
     [](const IntervalWithMidpoint& i){return i.midpoint();});
     std::ranges::sort(midpoints);
     ASSERT_EQ(midpoints, std::vector<float>({1.56, 1.6, 2.0, 2.0}));
+}
+
+TEST_F(IntervalTreeWithData, duplicateIntervals){
+    itree_.insert({1.5, 2.5, 3.0});
+    std::vector<IntervalWithMidpoint> intervals = itree_.findOverlaps(2.0);
+    EXPECT_EQ(intervals.size(), 5);
+
+    std::vector<float> midpoints;
+    std::transform(intervals.begin(), intervals.end(), std::back_inserter(midpoints), 
+    [](const IntervalWithMidpoint& i){return i.midpoint();});
+    std::ranges::sort(midpoints);
+}
+
+TEST(DuplicateData, duplicateIntervals2){
+    IntervalTree<IntervalWithMidpoint> itree_;
+    itree_.insert({0, 20, 0});
+    itree_.insert({50, 80, 0});
+    itree_.insert({0, 55, 1});
+    itree_.insert({75, 100, 1});
+    itree_.insert({0, 55, 2});
+    itree_.insert({80, 100, 2});
+
+    std::vector<IntervalWithMidpoint> overlaps = itree_.findOverlaps(15);
+    ASSERT_EQ(overlaps.size(), 3);
+    EXPECT_EQ(overlaps[0], IntervalWithMidpoint(0, 55, 2));
+    EXPECT_EQ(overlaps[1], IntervalWithMidpoint(0, 55, 1));
+    EXPECT_EQ(overlaps[2], IntervalWithMidpoint(0, 20, 0));
+
+    overlaps = itree_.findOverlaps(40);
+    ASSERT_EQ(overlaps.size(), 2);
+    EXPECT_EQ(overlaps[0], IntervalWithMidpoint(0, 55, 2));
+    EXPECT_EQ(overlaps[1], IntervalWithMidpoint(0, 55, 1));
+
+    std::vector<IntervalWithMidpoint> superset = itree_.findSupersets(15, 40);
+    EXPECT_EQ(overlaps, superset);
 }


### PR DESCRIPTION
Interval Tree improvements: 
More test cases, rename Itree::Interval<T> to SimpleInterval<T>, add overload of FindOverlaps() for intervals (not just points), add clear()